### PR TITLE
Fixed cloning images between different volume groups (only for one is…

### DIFF
--- a/datastore/clone
+++ b/datastore/clone
@@ -78,8 +78,9 @@ LV_NAME="lv-one-${ID}"
 IQN="$BASE_IQN:$DST_HOST.$VG_NAME.$LV_NAME"
 DEV="/dev/$VG_NAME/$LV_NAME"
 
+VG_SRC=$(echo $SRC|awk -F. '{print $(NF-1)}')
 LV_SRC=$(echo $SRC|awk -F. '{print $NF}')
-DEV_SRC="/dev/$VG_NAME/$LV_SRC"
+DEV_SRC="/dev/$VG_SRC/$LV_SRC"
 
 CLONE_CMD=$(cat <<EOF
     set -e


### PR DESCRIPTION
There is a bug about getting volume group name in cloning. Logical volume name is taken from SRC, but volume group name was taken from TARGET. Fixed.
Works only for volume groups on the same iscsi target (no remote copying between targets).
